### PR TITLE
Enable usage of local TSOA config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-tsoa",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "license": "MIT",
   "main": "dist/src/index.js",
   "files": [


### PR DESCRIPTION
This way we can configure how `serverless` runs in offline mode, by using the service's `tsoa.config` file.

Where I first noticed an issue, is in the `swagger.json` file being generated when running offline mode. The `servers` property was incorrectly generated:

```json
	"servers": [
		{
			"url": "/undefined"
		}
	]
```

causing all routes in the swagger docs to have `undefined` prepend to them.